### PR TITLE
add include_package_data=True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
     install_requires=required('requirements.txt'),
+    include_package_data=True,
     url='https://github.com/MycroftAI/mycroft-messagebus-client',
     license='Apache-2.0',
     author='Mycroft AI, Åke Forslund',


### PR DESCRIPTION
manifest being ignored and 0.8.3 broken on pip

quick fix made from browser, not really tested, hopefully solves #9 