### PR TITLE
Bugfix/requirements not found

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include LICENSE
+include LICENSE.md
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,10 @@ setup(
     version='0.8.3',
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
+    package_data={
+      '*': ['*.txt', '*.md']
+    },
+    include_package_data=True,
     install_requires=required('requirements.txt'),
     url='https://github.com/MycroftAI/mycroft-messagebus-client',
     license='Apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def required(requirements_file):
 
 setup(
     name='mycroft-messagebus-client',
-    version='0.8.3',
+    version='0.8.4',
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
     package_data={


### PR DESCRIPTION
Adds requirements to both the `MANIFEST.in` and `package_data` to ensure it is included in both source and binary distributions.

Also added the file extension to LICENSE in the MANIFEST.

Fixes #9 

### To test
```
python3 -m pip install --user --upgrade setuptools wheel
python3 setup.py sdist bdist_wheel
python3 -m pip install --user --upgrade twine
python3 -m twine check dist/*
```
Check that the generated package contains both LICENSE.md and requirements.txt