### PR TITLE
Wait for message

### DIFF
--- a/mycroft_bus_client/client/__init__.py
+++ b/mycroft_bus_client/client/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .client import MessageBusClient
+from .client import MessageBusClient, MessageWaiter

--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -31,6 +31,53 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
+class MessageWaiter:
+    """Wait for a single message.
+
+    Encapsulate the wait for a message logic separating the setup from
+    the actual waiting act so the waiting can be setuo, actions can be
+    performed and _then_ the message can be waited for.
+
+    Argunments:
+        bus: Bus to check for messages on
+        message_type: message type to wait for
+    """
+    def __init__(self, bus, message_type):
+        self.bus = bus
+        self.msg_type = message_type
+        self.received_msg = None
+        # Setup response handler
+        self.response_event = Event()
+        self.bus.once(message_type, self._handler)
+
+    def _handler(self, message):
+        """Receive response data."""
+        self.received_msg = message
+        self.response_event.set()
+
+    def wait(self, timeout=3.0):
+        """Wait for message.
+
+        Arguments:
+            timeout (int or float): seconds to wait for message
+
+        Returns:
+            Message or None
+        """
+        self.response_event.wait(timeout)
+        if not self.response_event.is_set():
+            # Clean up the event handler
+            try:
+                self.bus.remove(self.msg_type, self._handler)
+            except (ValueError, KeyError):
+                # ValueError occurs on pyee 5.0.1 removing handlers
+                # registered with once.
+                # KeyError may theoretically occur if the event occurs as
+                # the handler is removed
+                pass
+        return self.received_msg
+
+
 MessageBusClientConf = namedtuple('MessageBusClientConf',
                                   ['host', 'port', 'route', 'ssl'])
 
@@ -117,42 +164,36 @@ class MessageBusClient:
             LOG.warning('Could not send {} message because connection '
                         'has been closed'.format(message.msg_type))
 
-    def wait_for_response(self, message, reply_type=None, timeout=None):
+    def wait_for_message(self, message_type, timeout=3.0):
+        """Wait for a message of a specific type.
+
+        Arguments:
+            message_type (str): the message type of the expected message
+            timeout: seconds to wait before timeout, defaults to 3
+
+        Returns:
+            The received message or None if the response timed out
+        """
+
+        return MessageWaiter(self, message_type).wait(timeout)
+
+    def wait_for_response(self, message, reply_type=None, timeout=3.0):
         """Send a message and wait for a response.
 
-        Args:
+        Arguments:
             message (Message): message to send
             reply_type (str): the message type of the expected reply.
                               Defaults to "<message.msg_type>.response".
             timeout: seconds to wait before timeout, defaults to 3
+
         Returns:
             The received message or None if the response timed out
         """
-        response = []
-        response_event = Event()
-
-        def handler(message):
-            """Receive response data."""
-            response.append(message)
-            response_event.set()
-
-        # Setup response handler
-        self.once(reply_type or message.msg_type + '.response', handler)
-        # Send request
+        message_type = reply_type or message.msg_type + '.response'
+        waiter = MessageWaiter(self, message_type)  # Setup response handler
+        # Send message and wait for it's response
         self.emit(message)
-        # Wait for response
-        response_event.wait(timeout or 3.0)
-        if response_event.is_set():
-            return response[0]
-        try:
-            self.remove(reply_type, handler)
-        except (ValueError, KeyError):
-            # ValueError occurs on pyee 1.0.1 removing handlers
-            # registered with once.
-            # KeyError may theoretically occur if the event occurs as
-            # the handler is removed
-            pass
-        return None
+        return waiter.wait(timeout)
 
     def on(self, event_name, func):
         self.emitter.on(event_name, func)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def required(requirements_file):
 
 setup(
     name='mycroft-messagebus-client',
-    version='0.9.0',
+    version='0.9.1',
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
     package_data={

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from unittest.mock import Mock
+
 from mycroft_bus_client import MessageBusClient
+from mycroft_bus_client.client import MessageWaiter
+
 
 WS_CONF = {
     'websocket': {
@@ -34,3 +38,22 @@ class TestMessageBusClient:
     def test_create_client(self):
         mc = MessageBusClient()
         assert mc.client.url == 'ws://0.0.0.0:8181/core'
+
+
+class TestMessageWaiter:
+    def test_message_wait_success(self):
+        bus = Mock()
+        waiter = MessageWaiter(bus, 'delayed.message')
+        bus.once.assert_called_with('delayed.message', waiter._handler)
+
+        test_msg = Mock(name='test_msg')
+        waiter._handler(test_msg)  # Inject response
+
+        assert waiter.wait() == test_msg
+
+    def test_message_wait_timeout(self):
+        bus = Mock()
+        waiter = MessageWaiter(bus, 'delayed.message')
+        bus.once.assert_called_with('delayed.message', waiter._handler)
+
+        assert waiter.wait(0.3) is None


### PR DESCRIPTION
#### Description
Adds the missing `wait_for_message()` method along with the refactor of wait_for_response to use a shared MessageWaiter class.

This also incorporates the very excellent update from @NeonDaniel to utilize the Event instead of a sleep loop. See his description in #18.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [x] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Check unittests and assert that this keeps the speed added by @NeonDaniel.

