### PR TITLE
Upgrade websocket-client to 0.58.0

### DIFF
--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -107,17 +107,17 @@ class MessageBusClient:
         return WebSocketApp(url, on_open=self.on_open, on_close=self.on_close,
                             on_error=self.on_error, on_message=self.on_message)
 
-    def on_open(self):
+    def on_open(self, _):
         LOG.info("Connected")
         self.connected_event.set()
         self.emitter.emit("open")
         # Restore reconnect timer to 5 seconds on sucessful connect
         self.retry = 5
 
-    def on_close(self):
+    def on_close(self, _):
         self.emitter.emit("close")
 
-    def on_error(self, error):
+    def on_error(self, _, error):
         """ On error start trying to reconnect to the websocket. """
         if isinstance(error, WebSocketConnectionClosedException):
             LOG.warning('Could not send message because connection has closed')
@@ -143,7 +143,7 @@ class MessageBusClient:
         except WebSocketException:
             pass
 
-    def on_message(self, message):
+    def on_message(self, _, message):
         parsed_message = Message.deserialize(message)
         self.emitter.emit('message', message)
         self.emitter.emit(parsed_message.msg_type, parsed_message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-websocket-client==0.54.0
+websocket-client==0.58.0
 pyee==8.1.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def required(requirements_file):
 
 setup(
     name='mycroft-messagebus-client',
-    version='0.9.1',
+    version='0.9.2',
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
     package_data={


### PR DESCRIPTION
#### Description
Seems the API has changed a bit (although I can't find anything about
it) and websocket-client passes us the WebsocketApp object. Since we did
not accept this, the messagebus broke when using the latest
websocket-client available

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
First run messagebus-client without this PR and with websocket-client 0.58.0 and observe it breaking. Then apply this PR, keep the websocket-client 0.58.0 and observe it working properly again.