### PR TITLE
Allow custom emitter types

### DIFF
--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -94,9 +94,10 @@ class MessageBusClient:
     like the pyee EventEmitter and tries to offer as much convenience as
     possible to the developer.
     """
-    def __init__(self, host='0.0.0.0', port=8181, route='/core', ssl=False):
+    def __init__(self, host='0.0.0.0', port=8181, route='/core', ssl=False,
+                 emitter=ExecutorEventEmitter()):
         self.config = MessageBusClientConf(host, port, route, ssl)
-        self.emitter = ExecutorEventEmitter()
+        self.emitter = emitter
         self.client = self.create_client()
         self.retry = 5
         self.connected_event = Event()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -14,6 +14,8 @@
 #
 from unittest.mock import Mock
 
+from pyee import ExecutorEventEmitter
+
 from mycroft_bus_client import MessageBusClient
 from mycroft_bus_client.client import MessageWaiter
 
@@ -38,6 +40,15 @@ class TestMessageBusClient:
     def test_create_client(self):
         mc = MessageBusClient()
         assert mc.client.url == 'ws://0.0.0.0:8181/core'
+
+    def test_create_client_default_executor(self):
+        mc = MessageBusClient()
+        assert type(mc.emitter) == ExecutorEventEmitter
+
+    def test_create_client_custom_executor(self):
+        mock_emitter = Mock()
+        mc = MessageBusClient(emitter=mock_emitter)
+        assert mc.emitter == mock_emitter
 
 
 class TestMessageWaiter:


### PR DESCRIPTION
#### Description
Not all clients needs the threaded event emitter to operate. This allows the client to supply an emitter that suits the specific client / service. For example an async based emitter scheme might be more suitable for some or a completely synchronous emitter may work better in some cases.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
How can someone reviewing this PR test that it is working properly? Is there appropriate test coverage for this change?

#### Documentation
Does documentation for this already exist? Are there docstrings on all the public methods you added or modified? Have these been updated?
