### PR TITLE
Collect Responses

### DIFF
--- a/mycroft_bus_client/client/__init__.py
+++ b/mycroft_bus_client/client/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .client import MessageBusClient, MessageWaiter
+from .client import MessageBusClient, MessageWaiter, MessageCollector

--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -207,10 +207,10 @@ class MessageBusClient:
             collect_id = msg.context['__collect_id__']
             handler_id = str(uuid4())
             # Immediately respond that something is working on the issue
-            acknowledge = Message(msg.msg_type + '.handling',
-                                  data={'query': collect_id,
-                                        'handler': handler_id,
-                                        'timeout': timeout})
+            acknowledge = msg.reply(msg.msg_type + '.handling',
+                                    data={'query': collect_id,
+                                          'handler': handler_id,
+                                          'timeout': timeout})
             self.emit(acknowledge)
             func(CollectionMessage.from_message(msg, handler_id, collect_id))
         self.wrapped_funcs[func] = wrapper

--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -22,7 +22,7 @@ import json
 import logging
 import time
 import traceback
-from threading import Event, Thread, Lock
+from threading import Event, Thread
 from uuid import uuid4
 
 from pyee import ExecutorEventEmitter
@@ -33,170 +33,10 @@ from websocket import (WebSocketApp,
 from mycroft_bus_client.message import Message, CollectionMessage
 from mycroft_bus_client.util import create_echo_function
 
+from .collector import MessageCollector
+from .waiter import MessageWaiter
+
 LOG = logging.getLogger(__name__)
-
-
-class MessageWaiter:
-    """Wait for a single message.
-
-    Encapsulate the wait for a message logic separating the setup from
-    the actual waiting act so the waiting can be setuo, actions can be
-    performed and _then_ the message can be waited for.
-
-    Argunments:
-        bus: Bus to check for messages on
-        message_type: message type to wait for
-    """
-    def __init__(self, bus, message_type):
-        self.bus = bus
-        self.msg_type = message_type
-        self.received_msg = None
-        # Setup response handler
-        self.response_event = Event()
-        self.bus.once(message_type, self._handler)
-
-    def _handler(self, message):
-        """Receive response data."""
-        self.received_msg = message
-        self.response_event.set()
-
-    def wait(self, timeout=3.0):
-        """Wait for message.
-
-        Arguments:
-            timeout (int or float): seconds to wait for message
-
-        Returns:
-            Message or None
-        """
-        self.response_event.wait(timeout)
-        if not self.response_event.is_set():
-            # Clean up the event handler
-            try:
-                self.bus.remove(self.msg_type, self._handler)
-            except (ValueError, KeyError):
-                # ValueError occurs on pyee 5.0.1 removing handlers
-                # registered with once.
-                # KeyError may theoretically occur if the event occurs as
-                # the handler is removed
-                pass
-        return self.received_msg
-
-
-class MessageCollector:
-    """Collect multiple response.
-
-    This class encapsulates the logic for collecting messages from
-    multiple handlers returning the list of all answers.
-
-    Argunments:
-        bus: Bus to check for messages on
-        message (Message): message to send
-        min_timeout (int/float): Minimum time to wait for a response
-        max_timeout (int/float): Maximum allowed time to wait for an answer
-        direct_return (callable): Optional function for allowing an
-            early return (not all registered handlers need to respond)
-    """
-    def __init__(self, bus, message,
-            min_timeout, max_timeout,
-                 direct_return_func=None):
-        self.lock = Lock()
-        self.bus = bus
-        self.min_timeout = min_timeout
-        self.max_timeout = max_timeout
-        self.direct_return_func = direct_return_func or (lambda msg: False)
-
-        # Create an unique id for the collection
-        self.collect_id = str(uuid4())
-        self.handlers = {}
-        self.responses = {}
-        self.all_collected = Event()
-        self.message = message
-        self.message.context['__collect_id__'] = self.collect_id
-        self._start_time = 0
-
-    def _register_handler(self, msg):
-        """Handler for registration of collection handler.
-
-        Args:
-            msg: Message from handler.
-        """
-        handler_id = msg.data['handler']
-        timeout = msg.data['timeout']
-        with self.lock:
-            if (msg.data['query'] == self.collect_id and
-                    handler_id not in self.handlers):
-                previous_timeout = self.handlers.get(handler_id, 0)
-                self.handlers[handler_id] = previous_timeout + timeout
-
-    def _receive_response(self, msg):
-        """Handler for capturing final response from a handler.
-
-        Args:
-            msg: Message with collect handler's response.
-        """
-        with self.lock:
-            if msg.data['query'] == self.collect_id:
-                self.responses[msg.data['handler']] = msg
-                self.handlers[msg.data['handler']] = 0  # Reset timeout
-                # If all registered handlers have responded with an answer
-                # or a VERY good answer has been found indicate end of wait.
-                all_collected = len(self.responses) == len(self.handlers)
-                if (all_collected or self.direct_return_func(msg)):
-                    self.all_collected.set()
-
-    def _setup_collection_handlers(self):
-        """Create messages for handling and responses."""
-        base_msg_type = self.message.msg_type
-        self.bus.on(base_msg_type + '.handling', self._register_handler)
-        self.bus.on(base_msg_type + '.response', self._receive_response)
-
-    def _teardown_collection_handlers(self):
-        """Remove all registered handlers for response collection."""
-        base_msg_type = self.message.msg_type
-        self.bus.remove(base_msg_type + '.handling', self._register_handler)
-        self.bus.remove(base_msg_type + '.response', self._receive_response)
-
-    def collect(self):
-        """Call collect handlers and wait for them to finish."""
-        # Register handler to capture handlers trying to provide answer
-        self._setup_collection_handlers()
-        self.bus.emit(self.message)
-
-        time.sleep(self.min_timeout)
-        if len(self.handlers) == 0:
-            # No handlers has registered to answer the query
-            result = []
-        else:
-            result = self._wait_for_registered_handlers()
-
-        self._teardown_collection_handlers()
-        return result
-
-    def _wait_for_registered_handlers(self):
-        """
-        Wait until all handlers have sent a response or the timeout is reached.
-        """
-        # Reset the all_collected event if needed.
-        # May be set if the first registered message replies immediately before
-        # any other handlers has registered.
-        # TODO: check early return criteria
-        with self.lock:
-            all_collected = len(self.responses) == len(self.handlers)
-            if not all_collected:
-                self.all_collected.clear()
-
-        # Wait until all handlers have responded or timeout is reached
-        time_waited = self.min_timeout
-        remaining_timeout = max(self.handlers.values()) - time_waited
-        while remaining_timeout > 0.0 and time_waited < self.max_timeout:
-            if self.all_collected.wait(timeout=0.1):
-                break
-
-            time_waited += 0.1
-            remaining_timeout = max(self.handlers.values()) - time_waited
-
-        return [self.responses[key] for key in self.responses]
 
 
 MessageBusClientConf = namedtuple('MessageBusClientConf',

--- a/mycroft_bus_client/client/collector.py
+++ b/mycroft_bus_client/client/collector.py
@@ -1,0 +1,134 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from threading import Lock, Event
+from uuid import uuid4
+import time
+
+
+class MessageCollector:
+    """Collect multiple response.
+
+    This class encapsulates the logic for collecting messages from
+    multiple handlers returning the list of all answers.
+
+    Argunments:
+        bus: Bus to check for messages on
+        message (Message): message to send
+        min_timeout (int/float): Minimum time to wait for a response
+        max_timeout (int/float): Maximum allowed time to wait for an answer
+        direct_return_func (callable): Optional function for allowing an
+            early return (not all registered handlers need to respond)
+    """
+    def __init__(self, bus, message,
+                 min_timeout, max_timeout,
+                 direct_return_func=None):
+        self.lock = Lock()
+        self.bus = bus
+        self.min_timeout = min_timeout
+        self.max_timeout = max_timeout
+        self.direct_return_func = direct_return_func or (lambda msg: False)
+
+        # Create an unique id for the collection
+        self.collect_id = str(uuid4())
+        self.handlers = {}
+        self.responses = {}
+        self.all_collected = Event()
+        self.message = message
+        self.message.context['__collect_id__'] = self.collect_id
+        self._start_time = 0
+
+    def _register_handler(self, msg):
+        """Handler for registration of collection handler.
+
+        Args:
+            msg: Message from handler.
+        """
+        handler_id = msg.data['handler']
+        timeout = msg.data['timeout']
+        with self.lock:
+            if (msg.data['query'] == self.collect_id and
+                    handler_id not in self.handlers):
+                previous_timeout = self.handlers.get(handler_id, 0)
+                self.handlers[handler_id] = previous_timeout + timeout
+
+    def _receive_response(self, msg):
+        """Handler for capturing final response from a handler.
+
+        Args:
+            msg: Message with collect handler's response.
+        """
+        with self.lock:
+            if msg.data['query'] == self.collect_id:
+                self.responses[msg.data['handler']] = msg
+                self.handlers[msg.data['handler']] = 0  # Reset timeout
+                # If all registered handlers have responded with an answer
+                # or a VERY good answer has been found indicate end of wait.
+                all_collected = len(self.responses) == len(self.handlers)
+                if (all_collected or self.direct_return_func(msg)):
+                    self.all_collected.set()
+
+    def _setup_collection_handlers(self):
+        """Create messages for handling and responses."""
+        base_msg_type = self.message.msg_type
+        self.bus.on(base_msg_type + '.handling', self._register_handler)
+        self.bus.on(base_msg_type + '.response', self._receive_response)
+
+    def _teardown_collection_handlers(self):
+        """Remove all registered handlers for response collection."""
+        base_msg_type = self.message.msg_type
+        self.bus.remove(base_msg_type + '.handling', self._register_handler)
+        self.bus.remove(base_msg_type + '.response', self._receive_response)
+
+    def collect(self):
+        """Call collect handlers and wait for them to finish."""
+        # Register handler to capture handlers trying to provide answer
+        self._setup_collection_handlers()
+        self.bus.emit(self.message)
+
+        time.sleep(self.min_timeout)
+        if len(self.handlers) == 0:
+            # No handlers has registered to answer the query
+            result = []
+        else:
+            result = self._wait_for_registered_handlers()
+
+        self._teardown_collection_handlers()
+        return result
+
+    def _wait_for_registered_handlers(self):
+        """
+        Wait until all handlers have sent a response or the timeout is reached.
+        """
+        # Reset the all_collected event if needed.
+        # May be set if the first registered message replies immediately before
+        # any other handlers has registered.
+        # TODO: check early return criteria
+        with self.lock:
+            all_collected = len(self.responses) == len(self.handlers)
+            if not all_collected:
+                self.all_collected.clear()
+
+        # Wait until all handlers have responded or timeout is reached
+        time_waited = self.min_timeout
+        remaining_timeout = max(self.handlers.values()) - time_waited
+        while remaining_timeout > 0.0 and time_waited < self.max_timeout:
+            if self.all_collected.wait(timeout=0.1):
+                break
+
+            time_waited += 0.1
+            remaining_timeout = max(self.handlers.values()) - time_waited
+
+        return [self.responses[key] for key in self.responses]

--- a/mycroft_bus_client/client/waiter.py
+++ b/mycroft_bus_client/client/waiter.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from threading import Event
+
+
+class MessageWaiter:
+    """Wait for a single message.
+
+    Encapsulate the wait for a message logic separating the setup from
+    the actual waiting act so the waiting can be setuo, actions can be
+    performed and _then_ the message can be waited for.
+
+    Argunments:
+        bus: Bus to check for messages on
+        message_type: message type to wait for
+    """
+    def __init__(self, bus, message_type):
+        self.bus = bus
+        self.msg_type = message_type
+        self.received_msg = None
+        # Setup response handler
+        self.response_event = Event()
+        self.bus.once(message_type, self._handler)
+
+    def _handler(self, message):
+        """Receive response data."""
+        self.received_msg = message
+        self.response_event.set()
+
+    def wait(self, timeout=3.0):
+        """Wait for message.
+
+        Arguments:
+            timeout (int or float): seconds to wait for message
+
+        Returns:
+            Message or None
+        """
+        self.response_event.wait(timeout)
+        if not self.response_event.is_set():
+            # Clean up the event handler
+            try:
+                self.bus.remove(self.msg_type, self._handler)
+            except (ValueError, KeyError):
+                # ValueError occurs on pyee 5.0.1 removing handlers
+                # registered with once.
+                # KeyError may theoretically occur if the event occurs as
+                # the handler is removed
+                pass
+        return self.received_msg

--- a/mycroft_bus_client/message.py
+++ b/mycroft_bus_client/message.py
@@ -225,6 +225,8 @@ class CollectionMessage(Message):
         """Create a message indicating a successful result.
 
         The handler could handle the query and created some sort of response.
+        The source and destination is switched in the context like when
+        sending a normal response message.
 
             data (dict): message data
             context (dict): message context
@@ -235,15 +237,17 @@ class CollectionMessage(Message):
         data['query'] = self.query_id
         data['handler'] = self.handler_id
         data['succeeded'] = True
-        response_message = Message(self.msg_type + '.response',
-                                   data,
-                                   context or self.context)
+        response_message = self.reply(self.msg_type + '.response',
+                                      data,
+                                      context or self.context)
         return response_message
 
     def failure(self):
         """Create a message indicating a failing result.
 
         The handler could not handle the query.
+        The source and destination is switched in the context like when
+        sending a normal response message.
 
             data (dict): message data
             context (dict): message context
@@ -254,15 +258,17 @@ class CollectionMessage(Message):
         data['query'] = self.query_id
         data['handler'] = self.handler_id
         data['succeeded'] = False
-        response_message = Message(self.msg_type + '.response',
-                                   data,
-                                   self.context)
+        response_message = self.reply(self.msg_type + '.response',
+                                      data,
+                                      self.context)
         return response_message
 
     def extend(self, timeout):
         """Extend current timeout,
 
         The timeout provided will be added to the existing timeout.
+        The source and destination is switched in the context like when
+        sending a normal response message.
 
         Arguments:
             timeout (int/float): timeout extension
@@ -274,7 +280,7 @@ class CollectionMessage(Message):
         data['query'] = self.query_id
         data['handler'] = self.handler_id
         data['timeout'] = timeout
-        response_message = Message(self.msg_type + '.handling',
-                                   data,
-                                   self.context)
+        response_message = self.reply(self.msg_type + '.handling',
+                                      data,
+                                      self.context)
         return response_message

--- a/mycroft_bus_client/message.py
+++ b/mycroft_bus_client/message.py
@@ -259,5 +259,22 @@ class CollectionMessage(Message):
                                    self.context)
         return response_message
 
-    def extend(self):
-        """TODO: EXTEND THE TIMEOUT..."""
+    def extend(self, timeout):
+        """Extend current timeout,
+
+        The timeout provided will be added to the existing timeout.
+
+        Arguments:
+            timeout (int/float): timeout extension
+
+        Returns:
+            Extension message.
+        """
+        data = {}
+        data['query'] = self.query_id
+        data['handler'] = self.handler_id
+        data['timeout'] = timeout
+        response_message = Message(self.msg_type + '.handling',
+                                   data,
+                                   self.context)
+        return response_message

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def required(requirements_file):
 
 setup(
     name='mycroft-messagebus-client',
-    version='0.9.6',
+    version='0.10.0',
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
     package_data={

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -79,6 +79,7 @@ class TestMessageCollector:
         test_register = Mock(name='test_register')
         test_register.data = {
             'query': collector.collect_id,
+            'timeout': 5,
             'handler': 'test_handler1'
         }
         collector._register_handler(test_register)  # Inject response
@@ -100,11 +101,13 @@ class TestMessageCollector:
         valid_register = Mock(name='valid_register')
         valid_register.data = {
             'query': collector.collect_id,
+            'timeout': 5,
             'handler': 'test_handler1'
         }
         invalid_register = Mock(name='invalid_register')
         invalid_register.data = {
             'query': 'asdf',
+            'timeout': 5,
             'handler': 'test_handler1'
         }
         collector._register_handler(valid_register)  # Inject response


### PR DESCRIPTION
This aims to implement #20.

It implements a `collect_responses()` method similar to `wait_for_response()` that will wait for a number of handlers to process a message and respond.

To handle much of the boiler plate for returning a special `on_collect()` method can be used to register a handler for these calls.

The process right now is

Caller of `collect_responses()`
1. collect_responses is called
2. it registers some temporary message handlers (register answer handler, receive answer )
3. it emits the message
4. it then waits for a short time for handlers trying to answer the query to register
5. It waits for all registered handlers to respond or the max time to be reached.

`on_collect()` handler
1. A collect answers message is received
2. It immediately responds with an acknowledgement to be registered as a handler for the query
3. the handler method is called (like a normal message handler)
4. the handler method creates an appropriate response message

Example:
```python
import time
from mycroft_bus_client import MessageBusClient, Message

print('Setting up client to connect to a local mycroft instance')
client = MessageBusClient()

def collect_failed(message):
    print ("Collecting but failing")
    client.emit(message.failure())


def collect_ok(message):
    print ("Collecting and succeeding")
    client.emit(message.success(data={'answer': 'It\'s an aardwark'}))

print('Registering collect handlers...')
client.on_collect('test_message', collect_ok)
client.on_collect('test_message', collect_failed)

client.run_in_thread()

time.sleep(1)
start = time.time()
ret = client.collect_responses(Message('test_message'))
print("Collect took {}".format(time.time() - start))
for msg in ret:
    print(msg.data)
```

Not sure about letting the caller do the send, this could also be wrapped in the `on_collect()` method, but it makes it similar to the handling of `wait_for_response()` calls.

## TODO
- ~~handling extension of the timeout. I'm not 100% sure it's a feature that's needed but it can be good to have if a handler locks up.~~
- ~~Proper removal of the wrapped `on_collect` handler, since it's wrapped some remove logic needs to be added still.~~


Thoughts comment