### PR TITLE
Update websocket-client to 1.2.1 or compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-websocket-client==0.58.0
+websocket-client~=1.2.1
 pyee==8.1.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def required(requirements_file):
 
 setup(
     name='mycroft-messagebus-client',
-    version='0.9.2',
+    version='0.9.3',
     packages=['mycroft_bus_client', 'mycroft_bus_client.client',
               'mycroft_bus_client.util'],
     package_data={


### PR DESCRIPTION
#### Description
Simple version bump. I have run some basic tests and the client seems to work without further changes. This should resolve the questionable license.

#### Testing
Test this with puretryout's update of mycroft-core or make sure the examples in the readme works.