### PR TITLE
backward compatibility with websocket-client < 0.58.0

### DIFF
--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -121,7 +121,7 @@ class MessageBusClient:
         return WebSocketApp(url, on_open=self.on_open, on_close=self.on_close,
                             on_error=self.on_error, on_message=self.on_message)
 
-    def on_open(self, _):
+    def on_open(self, *args):
         """Handle the "open" event from the websocket.
 
         A Basic message with the name "open" is forwarded to the emitter.
@@ -132,15 +132,19 @@ class MessageBusClient:
         # Restore reconnect timer to 5 seconds on sucessful connect
         self.retry = 5
 
-    def on_close(self, _):
+    def on_close(self, *args):
         """Handle the "close" event from the websocket.
 
         A Basic message with the name "close" is forwarded to the emitter.
         """
         self.emitter.emit("close")
 
-    def on_error(self, _, error):
+    def on_error(self, *args):
         """On error start trying to reconnect to the websocket."""
+        if len(args) == 1:
+            error = args[0]
+        else:
+            error = args[1]
         if isinstance(error, WebSocketConnectionClosedException):
             LOG.warning('Could not send message because connection has closed')
         else:
@@ -164,12 +168,16 @@ class MessageBusClient:
         except WebSocketException:
             pass
 
-    def on_message(self, _, message):
+    def on_message(self, *args):
         """Handle incoming websocket message.
 
         Args:
             message (str): serialized Mycroft Message
         """
+        if len(args) == 1:
+            message = args[0]
+        else:
+            message = args[1]
         parsed_message = Message.deserialize(message)
         self.emitter.emit('message', message)
         self.emitter.emit(parsed_message.msg_type, parsed_message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-websocket-client~=1.2.1
+websocket-client>=0.54.0
 pyee==8.1.0


### PR DESCRIPTION
since 0.9.2 mycroft-bus-client is not backwards compatible because the signature of WebSocketApp methods changed (it now takes one extra argument)

this PR allows to use mycroft-bus-client with other programs that pin websocket-client < 0.58.0

I personally have a few packages pinning an older version, ironically to remain compatible with this same library that I now can't easily update without messing with a lot of repos
