### PR TITLE
do not share event emitter across all connections

### DIFF
--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -95,9 +95,9 @@ class MessageBusClient:
     possible to the developer.
     """
     def __init__(self, host='0.0.0.0', port=8181, route='/core', ssl=False,
-                 emitter=ExecutorEventEmitter()):
+                 emitter=None):
         self.config = MessageBusClientConf(host, port, route, ssl)
-        self.emitter = emitter
+        self.emitter = emitter or ExecutorEventEmitter()
         self.client = self.create_client()
         self.retry = 5
         self.connected_event = Event()


### PR DESCRIPTION
do not share event emitter across all connections

opening several bus connections in same process would cause event handlers to fire multiple times due to the shared pyee ExecutorEventEmitter()

when i applied this security patch https://github.com/HelloChatterbox/HolmesV/commit/5eb4ade8226a1546a6ac940fe2411be347dfb1e1 it caused a huge mess, the logs were full of duplicate events, one for each skill