### PR TITLE
Allow using loose requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ def required(requirements_file):
     base_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(base_dir, requirements_file), 'r') as f:
         requirements = f.read().splitlines()
+        if 'MYCROFT_LOOSE_REQUIREMENTS' in os.environ:
+            print('USING LOOSE REQUIREMENTS!')
+            requirements = [r.replace('==', '>=') for r in requirements]
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
 


### PR DESCRIPTION
Disabled by default. Useful for distribution packaging where we really
can't ship specific package versions depending on the package that needs
it. Distributions are responsible to make stuff works themselves anyway

The same is done in mycroft-core already