### PR TITLE
Handle ConnectionRefusedError that is thrown recursively on startup

### DIFF
--- a/mycroft_bus_client/client/client.py
+++ b/mycroft_bus_client/client/client.py
@@ -147,6 +147,8 @@ class MessageBusClient:
             error = args[1]
         if isinstance(error, WebSocketConnectionClosedException):
             LOG.warning('Could not send message because connection has closed')
+        elif isinstance(error, ConnectionRefusedError):
+            LOG.warning('Connection Refused. Is Messagebus Service running?')
         else:
             LOG.exception('=== %s ===', repr(error))
 


### PR DESCRIPTION
#### Description
Suppresses recusively logged traceback or ConnectionRefusedErrors. In many normal scenarios, a client might start at the same time as the messagebus and log several verbose errors because it cannot connec.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [ ] Feature implementation
- [x] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
This contains logging changes only. Instantiating a MessageBusClient with no accessible Messagebus Service now results in fewer log lines

#### Documentation
Does documentation for this already exist? Are there docstrings on all the public methods you added or modified? Have these been updated?
